### PR TITLE
Gentoo-friendly makefile for harvid

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -8,17 +8,17 @@ include ../common.mak
 
 CONFIGTEMP=conf.out
 
-ifeq ($(shell PKG_CONFIG_PATH=$(PKG_CONFIG_PATH) pkg-config --exists libavcodec libavformat libavutil libswscale || echo no), no)
-  $(error "http://ffmpeg.org is required - install libavcodec-dev, libswscale-dev, etc")
-endif
+#ifeq ($(shell PKG_CONFIG_PATH=$(PKG_CONFIG_PATH) pkg-config --exists libavcodec libavformat libavutil libswscale || echo no), no)
+#  $(error "http://ffmpeg.org is required - install libavcodec-dev, libswscale-dev, etc")
+#endif
 
-ifeq ($(shell PKG_CONFIG_PATH=$(PKG_CONFIG_PATH) pkg-config --exists libpng || echo no), no)
-  $(error "libpng is required - install libpng-dev")
-endif
+#ifeq ($(shell PKG_CONFIG_PATH=$(PKG_CONFIG_PATH) pkg-config --exists libpng || echo no), no)
+#  $(error "libpng is required - install libpng-dev")
+#endif
 
-ifeq ($(shell $(ECHO) "\#include <stdio.h>\n\#include <jpeglib.h>\nint main() { struct jpeg_error_mgr jerr; jpeg_std_error(&jerr); return 0; }" | $(CC) -pipe -x c -o $(CONFIGTEMP) $(ARCHINCLUDES) $(LDFLAGS) - -ljpeg 2>/dev/null || echo no; $(RM) -f $(CONFIGTEMP)), no)
-  $(error "libjpeg is required - install libjpeg-dev, libjpeg8-dev or libjpeg62-dev")
-endif
+#ifeq ($(shell $(ECHO) "\#include <stdio.h>\n\#include <jpeglib.h>\nint main() { struct jpeg_error_mgr jerr; jpeg_std_error(&jerr); return 0; }" | $(CC) -pipe -x c -o (CONFIGTEMP) $(ARCHINCLUDES) $(LDFLAGS) - -ljpeg 2>/dev/null || echo no; $(RM) -f $(CONFIGTEMP)), no)
+#  $(error "libjpeg is required - install libjpeg-dev, libjpeg8-dev or libjpeg62-dev")
+#endif
 
 FLAGS=-I../libharvid/
 FLAGS+=$(ARCHINCLUDES) $(ARCHFLAGS)


### PR DESCRIPTION
Hello, Robin

Recent changes to dependencies in Gentoo distribution caused failures in your dependency checks in src/Makefile. These checks must be implemented by the distribution package tools rather than the Makefile from my POV.

I've removed these checks in my version and I was able to build harvid w/o any problems.

I think it's the replacement of libjpeg to libjpeg-turbo that triggered this error for me.

KR
Anton.